### PR TITLE
More correct fix previous bag

### DIFF
--- a/ydbf/reader.py
+++ b/ydbf/reader.py
@@ -260,7 +260,7 @@ class YDbfReader(object):
                 # deleted record
                 continue
             try:
-                yield dict((name, conv(val.rstrip('\x00'), size, dec))
+                yield dict((name, conv(val.split('\x00', 1)[0], size, dec))
                             for (conv, name, size, dec), val
                             in izip(converters, record)
                             if (name != '_deletion_flag' or show_deleted))


### PR DESCRIPTION
В одном из DBF-оф наткнулся на такую ситуацию, когда в поле после значения и \0 идут остатки прошлых данных.
К сожалению файл не сохранился.
Читалки на C никаких неудобств не испытывают, т. к. строка естественным образом обрывается \0
